### PR TITLE
remove violet blue from bad word list

### DIFF
--- a/Regression/dirty.txt
+++ b/Regression/dirty.txt
@@ -341,7 +341,6 @@ urophilia
 vagina
 venus mound
 vibrator
-violet blue
 violet wand
 vorarephilia
 voyeur


### PR DESCRIPTION
It's a person's name, and not a vulgar phrase.
